### PR TITLE
Fix "buildpec" typo

### DIFF
--- a/doc_source/build-spec-ref.md
+++ b/doc_source/build-spec-ref.md
@@ -275,7 +275,7 @@ Commands in some build phases might not be run if commands in earlier build phas
       }
     ```
 
-    Then your buildpec looks like the following:
+    Then your build spec looks like the following:
 
     ```
     version: 0.2


### PR DESCRIPTION
*Description of changes:*

Changed "buildpec"to "build spec".

Apologies for the non-change on line 394; I guess the GitHub web editor has added/removed something from the end of the document.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
