### PR TITLE
Enterprise BitBucket Call out

### DIFF
--- a/doc_source/sample-bitbucket-pull-request.md
+++ b/doc_source/sample-bitbucket-pull-request.md
@@ -15,7 +15,7 @@ This sample shows you how to create a pull request using a Bitbucket repository\
 
 ## Bitbucket Pull Request Prerequisites<a name="sample-bitbucket-pull-request-prerequisites"></a>
 
- To run this sample you must connect your AWS CodeBuild project with your Bitbucket account\. 
+ To run this sample you must connect your AWS CodeBuild project with your Bitbucket account Note, that at this time CodeBuild does not support Enterprise BitBucket integration\. 
 
 **Note**  
  AWS CodeBuild has updated its permissions with Bitbucket\. If you previously connected your project to Bitbucket and now receive a Bitbucket connection error, you must reconnect to grant AWS CodeBuild permission to manage your webhooks\. 


### PR DESCRIPTION
Explicitly stating that bitbucket enterprise support is not available at this time for CB to avoid customer confusion

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
