### PR TITLE
Fix invalid YAML tabs in inline buildspec

### DIFF
--- a/doc_source/sample-multi-in-out.md
+++ b/doc_source/sample-multi-in-out.md
@@ -120,7 +120,7 @@ artifacts:
   "name": "project-name",
   "source": {
     "type": "NO_SOURCE",
-    "buildspec": "version: 0.2\n\nphases:\n\tbuild:\n\t\tcommands:\n\t\t\t- command"
+    "buildspec": "version: 0.2\n\nphases:\n  build:\n    commands:\n      - command"
    },
   "environment": {
     "type": "LINUX_CONTAINER",


### PR DESCRIPTION
*Issue #, if available:*

Tabs are not valid in the buildspec YAML
[Container] 2019/04/14 02:10:17 Phase context status code: YAML_FILE_ERROR Message: found character that cannot start any token at line 3 

*Description of changes:*
Change documentation to use 2 spaces instead of \t

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
