### PR TITLE
Docker build with CodeBuild requires privilegedMode

### DIFF
--- a/doc_source/sample-docker.md
+++ b/doc_source/sample-docker.md
@@ -113,7 +113,8 @@ If you are using an Amazon S3 input bucket, be sure to create a ZIP file that co
            "name": "IMAGE_TAG",
            "value": "latest"
          }
-       ]
+       ],
+       "privilegedMode": true
      },
      "serviceRole": "arn:aws:iam::account-ID:role/role-name",
      "encryptionKey": "arn:aws:kms:region-ID:account-ID:key/key-ID"


### PR DESCRIPTION
*Description of changes:*

This is just to add the missing `"privilegedMode": true` to the JSON\-formatted input to the `create-project` command, as using CodeBuild to build Docker requires privilegedMode = true.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
