### PR TITLE
Update GitHub and GHE webhook sample

### DIFF
--- a/doc_source/sample-github-enterprise.md
+++ b/doc_source/sample-github-enterprise.md
@@ -1,6 +1,6 @@
 # GitHub Enterprise Sample for CodeBuild<a name="sample-github-enterprise"></a>
 
-AWS CodeBuild supports GitHub Enterprise as a source repository\. This sample shows how to set up your CodeBuild projects when your GitHub Enterprise repository has a certificate installed\. It also shows how to enable webhooks so that CodeBuild rebuilds the source code every time a code change is pushed to your private GitHub Enterprise repository\.
+AWS CodeBuild supports GitHub Enterprise as a source repository\. This sample shows how to set up your CodeBuild projects when your GitHub Enterprise repository has a certificate installed\. It also shows how to enable webhooks so that CodeBuild rebuilds the source code every time a code change is pushed to your GitHub Enterprise repository\.
 
 ## Prerequisites<a name="sample-github-enterprise-prerequisites"></a>
 

--- a/doc_source/sample-github-pull-request.md
+++ b/doc_source/sample-github-pull-request.md
@@ -3,7 +3,7 @@
 AWS CodeBuild now supports webhooks, when the source repository is GitHub\. This means that for an AWS CodeBuild build project that has its source code stored in your GitHub repository, webhooks enable AWS CodeBuild to rebuild the source code every time a code change is pushed to the connected repository\.
 
 **Note**  
-To prevent changes in public repositories triggering unnecessary builds, you can use [filter groups](#sample-github-pull-request-filter-webhook-events) to specify which GitHub users can trigger builds 
+We recommend that you use a [filter group](#sample-github-pull-request-filter-webhook-events) to specify which GitHub users can trigger a build in a public repository. This can prevent a user from triggering an unexpected build.
 
 ## Create a Build Project with GitHub as the Source Repository and Enable Webhooks \(Console\)<a name="sample-github-pull-request-running"></a>
 

--- a/doc_source/sample-github-pull-request.md
+++ b/doc_source/sample-github-pull-request.md
@@ -1,6 +1,9 @@
 # GitHub Pull Request and Webhook Filter Sample for CodeBuild<a name="sample-github-pull-request"></a>
 
-AWS CodeBuild now supports webhooks, when the source repository is GitHub\. This means that for an AWS CodeBuild build project that has its source code stored in a private GitHub repository, webhooks enable AWS CodeBuild to rebuild the source code every time a code change is pushed to the private repository\.
+AWS CodeBuild now supports webhooks, when the source repository is GitHub\. This means that for an AWS CodeBuild build project that has its source code stored in your GitHub repository, webhooks enable AWS CodeBuild to rebuild the source code every time a code change is pushed to the connected repository\.
+
+**Note**  
+To prevent changes in public repositories triggering unnecessary builds, you can use [filter groups](#sample-github-pull-request-filter-webhook-events) to specify which GitHub users can trigger builds 
 
 ## Create a Build Project with GitHub as the Source Repository and Enable Webhooks \(Console\)<a name="sample-github-pull-request-running"></a>
 


### PR DESCRIPTION
*Issue #, if available:* 
Current webhook sample states that it can be created for private repositories. This is not accurate since we can configure webhooks on public repositories too.

*Description of changes:*
Updated the descriptions in the sample, and callout that you can use filter groups to avoid unnecessary builds triggered by changes in public repositories.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
