### PR TITLE
Fix name of CLI Reference link

### DIFF
--- a/doc_source/sample-access-tokens.md
+++ b/doc_source/sample-access-tokens.md
@@ -52,7 +52,7 @@ CodeBuild does not support Bitbucket Server\.
 
 ## Connect Source Providers with Access Tokens \(CLI\)<a name="sample-access-tokens-cli"></a>
 
-Follow these steps to use the AWS CLI to connect your project to GitHub or Bitbucket using access tokens\. For information about using the AWS CLI with AWS CodeBuild, see the [Use a Proxy ServerCommand Line Reference](cmd-ref.md)\. 
+Follow these steps to use the AWS CLI to connect your project to GitHub or Bitbucket using access tokens\. For information about using the AWS CLI with AWS CodeBuild, see the [Command Line Reference](cmd-ref.md)\. 
 
 1.  Run the import\-source\-credentials command: 
 


### PR DESCRIPTION
*Issue #, if available:*
Name of one of the links looks to be copy pasted too fast
*Description of changes:*

Changed "Use a Proxy ServerCommand Line Reference." to be just "Command Line Reference." which is the name of the page the link leads to.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
