### PR TITLE
Update sample-build-badges.md

### DIFF
--- a/doc_source/sample-build-badges.md
+++ b/doc_source/sample-build-badges.md
@@ -17,7 +17,7 @@ AWS CodeBuild now supports the use of build badges, which provide an embeddable,
 **Important**  
 Updating your project source might affect the accuracy of the project's build badges\.
 **Note**  
- CodeBuild does not support build badges with the S3 source provider\. Build badges are also not supported when CodeBuild project is part of a CodePipeline.
+ CodeBuild does not support build badges with the S3 source provider\. Because AWS CodePipeline uses S3 for artifact transfers, build badges are not supported for build projects that are part of a CodePipeline pipeline\.
 
 1. In **Environment**:
 

--- a/doc_source/sample-build-badges.md
+++ b/doc_source/sample-build-badges.md
@@ -17,7 +17,7 @@ AWS CodeBuild now supports the use of build badges, which provide an embeddable,
 **Important**  
 Updating your project source might affect the accuracy of the project's build badges\.
 **Note**  
- CodeBuild does not support build badges with the S3 source provider\. 
+ CodeBuild does not support build badges with the S3 source provider\. Build badges are also not supported when CodeBuild project is part of a CodePipeline.
 
 1. In **Environment**:
 


### PR DESCRIPTION
Added text 

"Build badges are also not supported when CodeBuild project is part of a CodePipeline." 

to clarify build badge support is not available when used as part of CodePipeline project.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
