### PR TITLE
Removed 7.4

### DIFF
--- a/doc_source/build-env-ref-available.md
+++ b/doc_source/build-env-ref-available.md
@@ -35,7 +35,7 @@ The `aws/codebuild/amazonlinux2-aarch64-standard:1.0` image does not support the
 | golang | 1\.13 | 
 | nodejs | 10\.18, 12\.14 | 
 | java | openjdk11 | 
-| php | 7\.3, 7\.4 | 
+| php | 7\.3 | 
 | python | 3\.7 | 
 | ruby | 2\.6 | 
 


### PR DESCRIPTION
There is no php7.4 in CodeBuild Linux environment

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
