### PR TITLE
Update amazon/aws-codebuild-local signature

### DIFF
--- a/doc_source/use-codebuild-agent.md
+++ b/doc_source/use-codebuild-agent.md
@@ -16,7 +16,7 @@
    codebuild_build.sh [-i image_name] [-a artifact_output_directory] [options]
    ```
 
- The CodeBuild agent is available from [https://hub\.docker\.com/r/amazon/aws\-codebuild\-local/](https://hub.docker.com/r/amazon/aws-codebuild-local/)\. Its Secure Hash Algorithm \(SHA\) signature is `94467b3eeac4184d28a38feb27a1530691527dd49c17e30ad1b6331d791e82f5`\. You can use this to identify the version of the agent\. To see the agent's SHA signature, run the following command: 
+ The CodeBuild agent is available from [https://hub\.docker\.com/r/amazon/aws\-codebuild\-local/](https://hub.docker.com/r/amazon/aws-codebuild-local/)\. Its Secure Hash Algorithm \(SHA\) signature is `bd69dbcdc9b3da66fd93de0b6d45534086367d6b48d3536d0248a01a459fb7e4`\. You can use this to identify the version of the agent\. To see the agent's SHA signature, run the following command: 
 
 ```
 docker inspect amazon/aws-codebuild-local


### PR DESCRIPTION
*Description of changes:*
Updated the SHA256 signature of the amazon/aws-codebuild-local docker image to reflect the current version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.