### PR TITLE
Update sample-build-notifications.md

### DIFF
--- a/doc_source/sample-build-notifications.md
+++ b/doc_source/sample-build-notifications.md
@@ -283,12 +283,12 @@ Build state change notifications use the following format:
   "time": "2017-09-01T16:14:28Z",
   "region": "us-west-2",
   "resources":[
-    "arn:aws:codebuild:us-west-2::123456789012:build/my-sample-project:8745a7a9-c340-456a-9166-edf953571bEX"
+    "arn:aws:codebuild:us-west-2:123456789012:build/my-sample-project:8745a7a9-c340-456a-9166-edf953571bEX"
   ],
   "detail":{
     "build-status": "SUCCEEDED",
     "project-name": "my-sample-project",
-    "build-id": "arn:aws:codebuild:us-west-2::123456789012:build/my-sample-project:8745a7a9-c340-456a-9166-edf953571bEX",
+    "build-id": "arn:aws:codebuild:us-west-2:123456789012:build/my-sample-project:8745a7a9-c340-456a-9166-edf953571bEX",
     "additional-information": {
       "artifact": {
         "md5sum": "da9c44c8a9a3cd4b443126e823168fEX",
@@ -413,12 +413,12 @@ Build phase change notifications use the following format:
   "time": "2017-09-01T16:14:21Z",
   "region": "us-west-2",
   "resources":[
-    "arn:aws:codebuild:us-west-2::123456789012:build/my-sample-project:8745a7a9-c340-456a-9166-edf953571bEX"
+    "arn:aws:codebuild:us-west-2:123456789012:build/my-sample-project:8745a7a9-c340-456a-9166-edf953571bEX"
   ],
   "detail":{
     "completed-phase": "COMPLETED",
     "project-name": "my-sample-project",
-    "build-id": "arn:aws:codebuild:us-west-2::123456789012:build/my-sample-project:8745a7a9-c340-456a-9166-edf953571bEX",
+    "build-id": "arn:aws:codebuild:us-west-2:123456789012:build/my-sample-project:8745a7a9-c340-456a-9166-edf953571bEX",
     "completed-phase-context": "[]",
     "additional-information": {
       "artifact": {


### PR DESCRIPTION
Remove one of the two colons from build ARN

*Issue #, if available:*
#60 
*Description of changes:*
I've remove one of the two colons of the build ARN that was specified in the documentation, the currently values for this parameter received have only one colon. 
Example:
```diff
- "arn:aws:codebuild:us-west-2::123456789012:build/my-sample-project:8745a7a9-c340-456a-9166-edf953571bEX"
+ "arn:aws:codebuild:us-west-2:123456789012:build/my-sample-project:8745a7a9-c340-456a-9166-edf953571bEX"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
