### PR TITLE
Update sample-test-report-cli.md

### DIFF
--- a/doc_source/sample-test-report-cli.md
+++ b/doc_source/sample-test-report-cli.md
@@ -46,13 +46,14 @@ You can use the CodeBuild API or the AWS CodeBuild console to access the test re
        "name": "report-name", 
        "type": "TEST", 
        "exportConfig": {
-           "type": "S3", 
-           "s3": {
+           "exportConfigType": "S3", 
+           "s3Destination": {
                "bucket": "bucket-name", 
                "path": "path-to-folder", 
                "packaging": "NONE"
+           }
        }
-       }
+   }
    ```
 
 1.  Run the following command in the directory that contains `CreateReportGroupInput.json`\. For `region`, specify your AWS Region \(for example, `us-east-2`\)\. 


### PR DESCRIPTION
Correct example JSON for `CreateReportGroupInput.json`

*Issue #, if available:*

None

*Description of changes:*

- Updated example for CreateReportGroupInput.json
- Adjusted to match schema described here: https://docs.aws.amazon.com/codebuild/latest/userguide/test-report-group-create-cfn.html
- Added missing closing '}'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
