### PR TITLE
Sample policy for CodeBuildAccess, with both cases

### DIFF
--- a/doc_source/sample-ecr.md
+++ b/doc_source/sample-ecr.md
@@ -81,32 +81,32 @@ If you are using an S3 input bucket, be sure to create a ZIP file that contains 
 
       ```
       {
-        "Version": "2012-10-17",
-        "Statement": [
-          {
-          "Sid": "CodeBuildAccessPrincipal",
-            "Effect": "Allow",
-            "Principal": {
-              "Service": "codebuild.amazonaws.com"
+        "Version":"2012-10-17",
+        "Statement":[
+            {
+              "Sid":"CodeBuildAccessPrincipal",
+              "Effect":"Allow",
+              "Principal":{
+                  "Service":"codebuild.amazonaws.com"
+              },
+              "Action":[
+                  "ecr:BatchCheckLayerAvailability",
+                  "ecr:BatchGetImage",
+                  "ecr:GetDownloadUrlForLayer"
+              ]
             },
-            "Action": [
-              "ecr:BatchCheckLayerAvailability",
-              "ecr:BatchGetImage",
-              "ecr:GetDownloadUrlForLayer"
-            ]
-          },
-          {
-            "Sid": "CodeBuildAccessCrossaccount",
-            "Effect": "Allow",
-            "Principal": {
-              "AWS": "arn:aws:iam::AWS-account-ID:root"
-            },
-            "Action": [
-              "ecr:GetDownloadUrlForLayer",
-              "ecr:BatchGetImage",
-              "ecr:BatchCheckLayerAvailability"
-            ]
-          }
+            {
+              "Sid":"CodeBuildAccessCrossaccount",
+              "Effect":"Allow",
+              "Principal":{
+                  "AWS":"arn:aws:iam::AWS-account-ID:root"
+              },
+              "Action":[
+                  "ecr:GetDownloadUrlForLayer",
+                  "ecr:BatchGetImage",
+                  "ecr:BatchCheckLayerAvailability"
+              ]
+            }
         ]
       }
       ```

--- a/doc_source/sample-ecr.md
+++ b/doc_source/sample-ecr.md
@@ -2,7 +2,7 @@
 
 This sample uses a Docker image in an Amazon Elastic Container Registry \(Amazon ECR\) image repository to build a sample Go project\.
 
-**Important**  
+**Important**
 Running this sample might result in charges to your AWS account\. These include possible charges for AWS CodeBuild and for AWS resources and actions related to Amazon S3, AWS KMS, CloudWatch Logs, and Amazon ECR\. For more information, see [CodeBuild pricing](http://aws.amazon.com/codebuild/pricing), [Amazon S3 pricing](http://aws.amazon.com/s3/pricing), [AWS Key Management Service pricing](http://aws.amazon.com/kms/pricing), [Amazon CloudWatch pricing](http://aws.amazon.com/cloudwatch/pricing), and [Amazon Elastic Container Registry pricing](http://aws.amazon.com/ecr/pricing)\.
 
 ## Running the sample<a name="sample-ecr-running"></a>
@@ -11,11 +11,11 @@ Running this sample might result in charges to your AWS account\. These include 
 
 1. To create and push the Docker image to your image repository in Amazon ECR, complete the steps in the "Running the sample" section of the [Docker sample](sample-docker.md)\.
 
-1. Create a Go project: 
+1. Create a Go project:
 
-   1. Create the files as described in the [Go project structure](#ecr-sample-go-project-file-structure) and [Go project files](#sample-ecr-go-project-files) sections of this topic, and then upload them to an S3 input bucket or an AWS CodeCommit, GitHub, or Bitbucket repository\. 
-**Important**  
-Do not upload `(root directory name)`, just the files inside of `(root directory name)`\.   
+   1. Create the files as described in the [Go project structure](#ecr-sample-go-project-file-structure) and [Go project files](#sample-ecr-go-project-files) sections of this topic, and then upload them to an S3 input bucket or an AWS CodeCommit, GitHub, or Bitbucket repository\.
+**Important**
+Do not upload `(root directory name)`, just the files inside of `(root directory name)`\.
 If you are using an S3 input bucket, be sure to create a ZIP file that contains the files, and then upload it to the input bucket\. Do not add `(root directory name)` to the ZIP file, just the files inside of `(root directory name)`\.
 
    1. Create a build project, run the build, and view related build information by following the steps in [Run AWS CodeBuild directly](how-to-run.md)\.
@@ -47,11 +47,11 @@ If you are using an S3 input bucket, be sure to create a ZIP file that contains 
 
    1. To get the build output artifact, open your S3 output bucket\.
 
-   1. Download the `GoOutputArtifact.zip` file to your local computer or instance, and then extract the contents of the file\. In the extracted contents, get the `hello` file\. 
+   1. Download the `GoOutputArtifact.zip` file to your local computer or instance, and then extract the contents of the file\. In the extracted contents, get the `hello` file\.
 
-1.  If one of the following is true, you must add permissions to your image repository in Amazon ECR so that AWS CodeBuild can pull its Docker image into the build environment\. 
-   +  Your project uses CodeBuild credentials to pull Amazon ECR images\. This is denoted by a value of `CODEBUILD` in the `imagePullCredentialsType` attribute of your `ProjectEnvironment`\. 
-   +  Your project uses a cross\-account Amazon ECR image\. In this case, your project must use its service role to pull Amazon ECR images\. To enable this behavior, set the `imagePullCredentialsType` attribute of your `ProjectEnvironment` to `SERVICE_ROLE`\. 
+1.  If one of the following is true, you must add permissions to your image repository in Amazon ECR so that AWS CodeBuild can pull its Docker image into the build environment\.
+   +  Your project uses CodeBuild credentials to pull Amazon ECR images\. This is denoted by a value of `CODEBUILD` in the `imagePullCredentialsType` attribute of your `ProjectEnvironment`\.
+   +  Your project uses a cross\-account Amazon ECR image\. In this case, your project must use its service role to pull Amazon ECR images\. To enable this behavior, set the `imagePullCredentialsType` attribute of your `ProjectEnvironment` to `SERVICE_ROLE`\.
 
    1. Open the Amazon ECR console at [https://console\.aws\.amazon\.com/ecr/](https://console.aws.amazon.com/ecr/)\.
 
@@ -64,7 +64,7 @@ If you are using an S3 input bucket, be sure to create a ZIP file that contains 
    1. For **Effect**, leave **Allow** selected\. This indicates that you want to allow access to another AWS account\.
 
    1. For **Principal**, do one of the following:
-      + If your project uses CodeBuild credentials to pull an Amazon ECR image, in **Service principal**, enter **codebuild\.amazonaws\.com**\. 
+      + If your project uses CodeBuild credentials to pull an Amazon ECR image, in **Service principal**, enter **codebuild\.amazonaws\.com**\.
       + If your project uses a cross\-account Amazon ECR image, for **AWS account IDs**, enter IDs of the AWS accounts that you want to give access\.
 
    1. Skip the **All IAM entities** list\.
@@ -84,10 +84,22 @@ If you are using an S3 input bucket, be sure to create a ZIP file that contains 
         "Version": "2012-10-17",
         "Statement": [
           {
-            "Sid": "CodeBuildAccess",
+          "Sid": "CodeBuildAccessPrincipal",
             "Effect": "Allow",
             "Principal": {
-              "AWS": "arn:aws:iam::AWS-account-ID:root"  
+              "Service": "codebuild.amazonaws.com"
+            },
+            "Action": [
+              "ecr:BatchCheckLayerAvailability",
+              "ecr:BatchGetImage",
+              "ecr:GetDownloadUrlForLayer"
+            ]
+          },
+          {
+            "Sid": "CodeBuildAccessCrossaccount",
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::AWS-account-ID:root"
             },
             "Action": [
               "ecr:GetDownloadUrlForLayer",
@@ -99,7 +111,7 @@ If you are using an S3 input bucket, be sure to create a ZIP file that contains 
       }
       ```
 
-1. Create a build project, run the build, and view build information by following the steps in [Run AWS CodeBuild directly](how-to-run.md)\.
+2. Create a build project, run the build, and view build information by following the steps in [Run AWS CodeBuild directly](how-to-run.md)\.
 
    If you use the AWS CLI to create the build project, the JSON\-formatted input to the `create-project` command might look similar to this\. \(Replace the placeholders with your own values\.\)
 
@@ -126,9 +138,9 @@ If you are using an S3 input bucket, be sure to create a ZIP file that contains 
    }
    ```
 
-1. To get the build output artifact, open your S3 output bucket\.
+3. To get the build output artifact, open your S3 output bucket\.
 
-1. Download the `GoOutputArtifact.zip` file to your local computer or instance, and then extract the contents of the `GoOutputArtifact.zip` file\. In the extracted contents, get the `hello` file\.
+4. Download the `GoOutputArtifact.zip` file to your local computer or instance, and then extract the contents of the `GoOutputArtifact.zip` file\. In the extracted contents, get the `hello` file\.
 
 ## Go project structure<a name="ecr-sample-go-project-file-structure"></a>
 
@@ -150,14 +162,14 @@ This sample uses these files\.
 version: 0.2
 
 phases:
-  install: 
-   runtime-versions: 
-     golang: 1.13 
+  install:
+   runtime-versions:
+     golang: 1.13
   build:
     commands:
       - echo Build started on `date`
       - echo Compiling the Go code...
-      - go build hello.go 
+      - go build hello.go
   post_build:
     commands:
       - echo Build completed on `date`


### PR DESCRIPTION
*Description of changes:*

The sample policy shows only one case, the cross-account CodeBuildAccess.

I've included the sample code for a policy with the most common use-case of the CodeBuild principal and as the second case the cross-account CodeBuildAccess.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
