### PR TITLE
Fix spelling mistake "mulitple" to "multiple"

### DIFF
--- a/doc_source/sample-buildspec-artifact-naming.md
+++ b/doc_source/sample-buildspec-artifact-naming.md
@@ -2,7 +2,7 @@
 
  This sample contains example buildspec files that demonstrate how to specify an artifact name that is created at build time\. A name specified in a buildspec file can incorporate Shell commands and environment variables to make it unique\. A name you specify in a buildspec file overrides a name you enter in the console when you create your project\.
 
- If you build mulitple times, using an artifact name specified in the buildspec file can ensure your output artifact file names are unique\. For example, you can use a date and timestamp that is inserted into an artifact name at build time\. 
+ If you build multiple times, using an artifact name specified in the buildspec file can ensure your output artifact file names are unique\. For example, you can use a date and timestamp that is inserted into an artifact name at build time\. 
 
 If you want to override the artifact name you entered in the console with a name in the buildspec file, do the following:
 


### PR DESCRIPTION
*Issue #, if available:* Spelling typo for "multiple"

*Description of changes:* Changed "mulitple" to "multiple"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
