### PR TITLE
add missing RetryBuild action

### DIFF
--- a/doc_source/auth-and-access-control-permissions-reference.md
+++ b/doc_source/auth-and-access-control-permissions-reference.md
@@ -148,6 +148,11 @@ StopBuild
 Required to attempt to stop running builds\.  
  **Resource:** `arn:aws:codebuild:region-ID: account-ID:project/ project-name ` 
 
+RetryBuild  
+ **Action:** `codebuild:RetryBuild`  
+Required to attempt to retry execution of a build\.  
+ **Resource:** `arn:aws:codebuild:region-ID: account-ID:project/ project-name`
+
 UpdateProject  
  **Actions:** `codebuild:UpdateProject`, `iam:PassRole`   
 Required to change information about builds\.  


### PR DESCRIPTION
*Issue #, if available:*
No open issue.

*Description of changes:*
Until recently, "stop" and "start" IAM actions alone, allowed us to retry execution of a codebuild project (using the Retry button).
As of recent, out of (What felt to me at least) no where, we can no longer retry execution of builds while having just "stop" and "start" actions in the IAM policy. getting unauthorized.
After looking at the IAM policy visualizer now (us-east-1), I see there's a "RetryBuild" action, which is required.
I couldn't find the RetryBuild action in the docs, so adding it via this PR. 

![image](https://user-images.githubusercontent.com/12733941/89183368-c9c70080-d59f-11ea-8bd3-377ddbfbfe6d.png)


Thanks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
