### PR TITLE
fix artifacts example

### DIFF
--- a/doc_source/sample-pipeline-multi-input-output.md
+++ b/doc_source/sample-pipeline-multi-input-output.md
@@ -117,6 +117,8 @@ An AWS CodeBuild project can take more than one input source\. It can also creat
         - touch source2_file
   
   artifacts:
+    files:
+      - **/*
     secondary-artifacts:
       artifact1:
         base-directory: $CODEBUILD_SRC_DIR


### PR DESCRIPTION
The example as written does not work.  The [AWS CodeBuild specification](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) provides a better example and this is a partial copy of that.

*Description of changes:*
I only added the `files` section to the `artifacts` element.  I don't know why the `After you create the JSON file...` line keeps getting stuck in there but I'm leaving it alone.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
