### PR TITLE
Use standard:5.0 in local codebuild guide

### DIFF
--- a/doc_source/use-codebuild-agent.md
+++ b/doc_source/use-codebuild-agent.md
@@ -22,11 +22,11 @@ You only need to set up the build image the first time you run the agent, or whe
    $ git clone https://github.com/aws/aws-codebuild-docker-images.git
    ```
 
-1. Build the image\. For this example, use the `aws/codebuild/standard:4.0` image\. This will take several minutes\.
+1. Build the image\. For this example, use the `aws/codebuild/standard:5.0` image\. This will take several minutes\.
 
    ```
-   $ cd aws-codebuild-docker-images/ubuntu/standard/4.0
-   $ docker build -t aws/codebuild/standard:4.0 .
+   $ cd aws-codebuild-docker-images/ubuntu/standard/5.0
+   $ docker build -t aws/codebuild/standard:5.0 .
    ```
 
 1. Download the agent\.
@@ -81,13 +81,13 @@ You only need to set up the build image the first time you run the agent, or whe
    To run an x86\_64 build, run the following command:
 
    ```
-   $ ./codebuild_build.sh -i aws/codebuild/standard:4.0 -a <output directory>
+   $ ./codebuild_build.sh -i aws/codebuild/standard:5.0 -a <output directory>
    ```
 
    To run an ARM build, run the following command:
 
    ```
-   $ ./codebuild_build.sh -i aws/codebuild/standard:4.0 -a <output directory> -l amazon/aws-codebuild-local:aarch64
+   $ ./codebuild_build.sh -i aws/codebuild/standard:5.0 -a <output directory> -l amazon/aws-codebuild-local:aarch64
    ```
 
    The script launches the build image and runs the build on the project in the current directory\. To specify the location of the build project, add the `-s <build project directory>` option to the script command\.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Standard 5.0 image was released on 2021/01/08
https://github.com/aws/aws-codebuild-docker-images/releases/tag/21.01.08

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
