### PR TITLE
Fix agent version in Run the CodeBuild agent steps

### DIFF
--- a/doc_source/use-codebuild-agent.md
+++ b/doc_source/use-codebuild-agent.md
@@ -86,13 +86,13 @@ You only need to set up the build image the first time you run the agent, or whe
    To run an x86\_64 build, run the following command:
 
    ```
-   $ ./codebuild_build.sh -i aws/codebuild/standard:4.0 -a <output directory>
+   $ ./codebuild_build.sh -i aws/codebuild/standard:5.0 -a <output directory>
    ```
 
    To run an ARM build, run the following command:
 
    ```
-   $ ./codebuild_build.sh -i aws/codebuild/standard:4.0 -a <output directory> -l amazon/aws-codebuild-local:aarch64
+   $ ./codebuild_build.sh -i aws/codebuild/standard:5.0 -a <output directory> -l amazon/aws-codebuild-local:aarch64
    ```
 
    The script launches the build image and runs the build on the project in the current directory\. To specify the location of the build project, add the `-s <build project directory>` option to the script command\.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
The "Set up the build image" steps instruct the user how to install version 5 of the image however the run steps still say to run version 4. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
