### PR TITLE
fix: remove dash from COMMIT_MESSAGE pattern item

### DIFF
--- a/doc_source/github-webhook.md
+++ b/doc_source/github-webhook.md
@@ -242,5 +242,5 @@ CodeBuildProject:
         - - Type: EVENT
             Pattern: PUSH
           - Type: COMMIT_MESSAGE
-          - Pattern: \[CodeBuild\]
+            Pattern: \[CodeBuild\]
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

... because it belongs to the type filtergroup item above and is not a new item in the list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
